### PR TITLE
InfluxDBMixin: Remove unnecessary quotes from tags.

### DIFF
--- a/docs/history.rst
+++ b/docs/history.rst
@@ -3,6 +3,10 @@
 Release History
 ===============
 
+`Next Release`_
+---------------
+- Remove extraneous quotes from InfluxDB tag values.
+
 `0.9.0`_ (27-Jan-2016)
 ----------------------
 - Add :class:`sprockets.mixins.metrics.StatsdMixin`

--- a/sprockets/mixins/metrics/influxdb.py
+++ b/sprockets/mixins/metrics/influxdb.py
@@ -137,6 +137,6 @@ class InfluxDBMixin(object):
         self.record_timing(self.request.request_time(), 'duration')
         self.settings[self.SETTINGS_KEY]['db_connection'].submit(
             self.settings[self.SETTINGS_KEY]['measurement'],
-            ('{}="{}"'.format(k, v) for k, v in self.__tags.items()),
+            ('{}={}'.format(k, v) for k, v in self.__tags.items()),
             self.__metrics,
         )

--- a/tests.py
+++ b/tests.py
@@ -146,10 +146,9 @@ class InfluxDbTests(testing.AsyncHTTPTestCase):
             if key.startswith('my-service,'):
                 tag_dict = dict(a.split('=') for a in key.split(',')[1:])
                 self.assertEqual(tag_dict['handler'],
-                                 '"examples.influxdb.SimpleHandler"')
-                self.assertEqual(tag_dict['method'], '"GET"')
-                self.assertEqual(tag_dict['host'],
-                                 '"{}"'.format(socket.gethostname()))
+                                 'examples.influxdb.SimpleHandler')
+                self.assertEqual(tag_dict['method'], 'GET')
+                self.assertEqual(tag_dict['host'], socket.gethostname())
 
                 value_dict = dict(a.split('=') for a in fields.split(','))
                 assert_between(0.25, float(value_dict['duration']), 0.3)
@@ -205,8 +204,7 @@ class InfluxDbTests(testing.AsyncHTTPTestCase):
         for key, fields, timestamp in self.influx_messages:
             if key.startswith('my-service,'):
                 tag_dict = dict(a.split('=') for a in key.split(',')[1:])
-                self.assertEqual(tag_dict['correlation_id'],
-                                 '"{}"'.format(cid))
+                self.assertEqual(tag_dict['correlation_id'], cid)
                 break
         else:
             self.fail('Expected to find "request" metric in {!r}'.format(


### PR DESCRIPTION
It turns out that tag values are always treated as string values so the quotes are not necessary.  This addresses issue #4.
