### PR TITLE
Move status code to a tag in the InfluxDB implementation.

### DIFF
--- a/docs/history.rst
+++ b/docs/history.rst
@@ -6,6 +6,7 @@ Release History
 `Next Release`_
 ---------------
 - Remove extraneous quotes from InfluxDB tag values.
+- Convert HTTP status code from value to a tag in the InfluxDB mix-in.
 
 `0.9.0`_ (27-Jan-2016)
 ----------------------

--- a/sprockets/mixins/metrics/influxdb.py
+++ b/sprockets/mixins/metrics/influxdb.py
@@ -133,7 +133,7 @@ class InfluxDBMixin(object):
 
     def on_finish(self):
         super(InfluxDBMixin, self).on_finish()
-        self.__metrics.append('status_code={}'.format(self._status_code))
+        self.set_metric_tag('status_code', self._status_code)
         self.record_timing(self.request.request_time(), 'duration')
         self.settings[self.SETTINGS_KEY]['db_connection'].submit(
             self.settings[self.SETTINGS_KEY]['measurement'],

--- a/tests.py
+++ b/tests.py
@@ -149,10 +149,10 @@ class InfluxDbTests(testing.AsyncHTTPTestCase):
                                  'examples.influxdb.SimpleHandler')
                 self.assertEqual(tag_dict['method'], 'GET')
                 self.assertEqual(tag_dict['host'], socket.gethostname())
+                self.assertEqual(tag_dict['status_code'], '204')
 
                 value_dict = dict(a.split('=') for a in fields.split(','))
                 assert_between(0.25, float(value_dict['duration']), 0.3)
-                self.assertEqual(value_dict['status_code'], '204')
 
                 nanos_since_epoch = int(timestamp)
                 then = nanos_since_epoch / 1000000000


### PR DESCRIPTION
InfluxDB only indexes measurement tags so the status code really needs to be a tag so that we can search on it.
