### PR TITLE
Implement collector/periodic callback

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -18,7 +18,6 @@ call to the ``get`` method as well as a separate metric for the database query.
 
    from sprockets.mixins import mediatype
    from sprockets.mixins.metrics import statsd
-   from tornado import web
    from tornado import gen, web
    import queries
 

--- a/README.rst
+++ b/README.rst
@@ -1,14 +1,41 @@
 sprockets.mixins.metrics
 ========================
-Adjust counter and timer metrics in InfluxDB or Graphite using the same API.
+Adjust counter and timer metrics in `InfluxDB`_ or `StatsD`_ using the same API.
+
+The mix-in is configured through the ``tornado.web.Application`` settings
+property using a key defined by the specific mix-in.
+
+Statsd Mixin
+------------
+
+The following snippet configures the StatsD mix-in from common environment
+variables. This simple handler will emit a timer metric that identifies each
+call to the ``get`` method as well as a separate metric for the database query.
 
 .. code-block:: python
 
-   from sprockets.mixins import mediatype, metrics
+   import os
+
+   from sprockets.mixins import mediatype
+   from sprockets.mixins.metrics import statsd
+   from tornado import web
    from tornado import gen, web
    import queries
 
-   class MyHandler(metrics.StatsdMixin, mediatype.ContentMixin,
+   def make_application():
+       settings = {
+           statsd.SETTINGS_KEY: {
+               'namespace': 'my-application',
+               'host': os.environ.get('STATSD_HOST', '127.0.0.1'),
+               'port': os.environ.get('STATSD_PORT', '8125'),
+           }
+       }
+       return web.Application([
+           # insert handlers here
+       ], **settings)
+
+   class MyHandler(statsd.StatsdMixin,
+                   mediatype.ContentMixin,
                    web.RequestHandler):
 
        def initialize(self):
@@ -22,38 +49,8 @@ Adjust counter and timer metrics in InfluxDB or Graphite using the same API.
                                            obj_id)
            self.send_response(result)
 
-This simple handler will emit a timer metric that identifies each call to the
-``get`` method as well as a separate metric for the database query.  Switching
-from using `statsd`_ to `InfluxDB`_ is simply a matter of switch from the
-``metrics.StatsdMixin`` to the ``metrics.InfluxDBMixin``.
-
-The mix-in is configured through the ``tornado.web.Application`` settings
-property using a key defined by the specific mix-in.
-
-Statsd Mixin
-------------
-
-The following snippet configures the StatsD mix-in from common environment
-variables:
-
-.. code-block:: python
-
-   import os
-
-   from sprockets.mixins import metrics
-   from tornado import web
-
-   def make_application():
-       settings = {
-           metrics.StatsdMixin.SETTINGS_KEY: {
-               'namespace': 'my-application',
-               'host': os.environ.get('STATSD_HOST', '127.0.0.1'),
-               'port': os.environ.get('STATSD_PORT', '8125'),
-           }
-       }
-       return web.Application([
-           # insert handlers here
-       ], **settings)
+Settings
+^^^^^^^^
 
 :namespace: The namespace for the measurements
 :host: The Statsd host
@@ -69,32 +66,55 @@ variables:
 
    import os
 
-   from sprockets.mixins import metrics
-   from tornado import web
+   from sprockets.mixins.metrics import influxdb
+   from sprockets.mixins import postgresql
+   from tornado import gen, web
 
-   def make_application():
-       settings = {
-           metrics.InfluxDBMixin.SETTINGS_KEY: {
-               'measurement': 'my-application',
-               'database': 'services',
-               'write_url': 'http://{}:{}/write'.format(
-                    os.environ.get('INFLUX_HOST', '127.0.0.1'),
-                    os.environ.get('INFLUX_PORT', 8086)),
-                'max_buffer_time': 3,
-                'max_buffer_length': 100
-           }
+   def make_app(**settings):
+       settings[influxdb.SETTINGS_KEY] = {
+           'measurement': 'rollup',
        }
-       return web.Application([
-           # insert handlers here
-       ], **settings)
 
-:measurement: The InfluxDB measurement name
-:database: The InfluxDB database to write measurements into
-:write_url: the InfluxDB write URL to send HTTP requests to
-:max_buffer_time: The maximum elasped time measurements should remain in
-    buffer before writing to InfluxDB.
-:max_buffer_length: The maximum number of measurements to
-    buffer before writing to InfluxDB.
+       application = web.Application(
+           [
+               web.url(r'/', RequestHandler),
+           ], **settings)
+
+       influxdb.install({'url': 'http://localhost:8086',
+                         'database': 'tornado-app'})
+       return application
+
+
+   class MyHandler(influxdb.InfluxDBMixin,
+                   postgresql.HandlerMixin,
+                   web.RequestHandler):
+
+       @gen.coroutine
+       def get(self, obj_id):
+           with self.execution_timer('dbquery', 'get'):
+              result = yield self.postgresql_session.query(
+                  'SELECT * FROM foo WHERE id=%s', obj_id)
+           self.send_response(result)
+
+If your application handles signal handling for shutdowns, the
+:meth:`~sprockets.mixins.influxdb.shutdown` method will try to cleanly ensure
+that any buffered metrics in the InfluxDB collector are written prior to
+shutting down. The method returns a :cls:`~tornado.concurrent.TracebackFuture`
+that should be waited on prior to shutting down.
+
+Settings
+^^^^^^^^
+
+:url: The InfluxDB API URL
+:database: the database to write measurements into
+:submission_interval: How often to submit metric batches in
+   milliseconds. Default: ``5000``
+:max_batch_size: The number of measurements to be submitted in a
+   single HTTP request. Default: ``1000``
+:tags: Default tags that are to be submitted with each metric. The tag
+   ``hostname`` is added by default along with ``environment`` and ``service``
+   if the corresponding ``ENVIRONMENT`` or ``SERVICE`` environment variables
+   are set.
 
 Development Quickstart
 ----------------------
@@ -104,6 +124,13 @@ Development Quickstart
    $ . ./env/bin/activate
    (env)$ env/bin/pip install -r requires/development.txt
    (env)$ nosetests
+   test_metrics_with_buffer_not_flush (tests.InfluxDbTests) ... ok
+   test_that_cached_db_connection_is_used (tests.InfluxDbTests) ... ok
+   test_that_counter_is_tracked (tests.InfluxDbTests) ... ok
+   test_that_execution_timer_is_tracked (tests.InfluxDbTests) ... ok
+   test_that_http_method_call_details_are_recorded (tests.InfluxDbTests) ... ok
+   test_that_metric_tag_is_tracked (tests.InfluxDbTests) ... ok
+   test_that_add_metric_tag_is_ignored (tests.StatsdMethodTimingTests) ... ok
    test_that_cached_socket_is_used (tests.StatsdMethodTimingTests) ... ok
    test_that_counter_accepts_increment_value (tests.StatsdMethodTimingTests) ... ok
    test_that_counter_increment_defaults_to_one (tests.StatsdMethodTimingTests) ... ok
@@ -112,12 +139,12 @@ Development Quickstart
    test_that_http_method_call_is_recorded (tests.StatsdMethodTimingTests) ... ok
 
    ----------------------------------------------------------------------
-   Ran 6 tests in 1.089s
+   Ran 13 tests in 3.572s
 
    OK
    (env)$ ./setup.py build_sphinx -q
    running build_sphinx
    (env)$ open build/sphinx/html/index.html
 
-.. _statsd: https://github.com/etsy/statsd
+.. _StatsD: https://github.com/etsy/statsd
 .. _InfluxDB: https://influxdata.com

--- a/examples/influxdb.py
+++ b/examples/influxdb.py
@@ -1,11 +1,10 @@
-import os
 import signal
 
-from sprockets.mixins import metrics
+from sprockets.mixins.metrics import influxdb
 from tornado import concurrent, gen, ioloop, web
 
 
-class SimpleHandler(metrics.InfluxDBMixin, web.RequestHandler):
+class SimpleHandler(influxdb.InfluxDBMixin, web.RequestHandler):
     """
     Simply emits a few metrics around the GET method.
 
@@ -65,17 +64,14 @@ def make_application():
     by the ``service`` setting.
 
     """
-    influx_url = 'http://{}:{}/write'.format(
-        os.environ.get('INFLUX_HOST', '127.0.0.1'),
-        os.environ.get('INFLUX_PORT', 8086))
     settings = {
-        metrics.InfluxDBMixin.SETTINGS_KEY: {
-            'measurement': 'cli',
-            'database': 'testing',
-            'write_url': influx_url,
+        influxdb.SETTINGS_KEY: {
+            'measurement': 'example',
         }
     }
-    return web.Application([web.url('/', SimpleHandler)], **settings)
+    application = web.Application([web.url('/', SimpleHandler)], **settings)
+    influxdb.install(application, **{'database': 'testing'})
+    return application
 
 
 if __name__ == '__main__':

--- a/examples/statsd.py
+++ b/examples/statsd.py
@@ -1,10 +1,10 @@
 import signal
 
-from sprockets.mixins import metrics
+from sprockets.mixins.metrics import statsd
 from tornado import concurrent, gen, ioloop, web
 
 
-class SimpleHandler(metrics.StatsdMixin, web.RequestHandler):
+class SimpleHandler(statsd.StatsdMixin, web.RequestHandler):
     """
     Simply emits a timing metric around the method call.
 
@@ -53,7 +53,7 @@ def make_application():
 
     """
     settings = {
-        metrics.StatsdMixin.SETTINGS_KEY: {
+        statsd.SETTINGS_KEY: {
             'namespace': 'webapps',
             'host': '127.0.0.1',
             'port': 8125,

--- a/sprockets/mixins/metrics/__init__.py
+++ b/sprockets/mixins/metrics/__init__.py
@@ -1,13 +1,3 @@
-try:
-    from .influxdb import InfluxDBMixin
-    from .statsd import StatsdMixin
-except ImportError as error:
-    def InfluxDBMixin(*args, **kwargs):
-        raise error
-
-    def StatsdMixin(*args, **kwargs):
-        raise error
-
-version_info = (1, 1, 1)
+version_info = (2, 0, 0)
 __version__ = '.'.join(str(v) for v in version_info)
-__all__ = ['__version__', 'version_info', 'InfluxDBMixin', 'StatsdMixin']
+__all__ = ['__version__', 'version_info']

--- a/sprockets/mixins/metrics/influxdb.py
+++ b/sprockets/mixins/metrics/influxdb.py
@@ -127,7 +127,6 @@ class InfluxDBCollector(object):
                  io_loop=None, submission_interval=SUBMISSION_INTERVAL,
                  max_batch_size=MAX_BATCH_SIZE, tags=None):
         self._buffer = list()
-        self._client.configure(None, defaults={'user_agent': _USER_AGENT})
         self._database = database
         self._influxdb_url = '{}?db={}'.format(url, database)
         self._interval = submission_interval or self.SUBMISSION_INTERVAL
@@ -138,6 +137,7 @@ class InfluxDBCollector(object):
 
         self._client = httpclient.AsyncHTTPClient(force_instance=True,
                                                   io_loop=self._io_loop)
+        self._client.configure(None, defaults={'user_agent': _USER_AGENT})
 
         # Add the periodic callback for submitting metrics
         LOGGER.info('Starting PeriodicCallback for writing InfluxDB metrics')

--- a/sprockets/mixins/metrics/influxdb.py
+++ b/sprockets/mixins/metrics/influxdb.py
@@ -127,7 +127,6 @@ class InfluxDBCollector(object):
                  io_loop=None, submission_interval=SUBMISSION_INTERVAL,
                  max_batch_size=MAX_BATCH_SIZE, tags=None):
         self._buffer = list()
-        self._client = httpclient.AsyncHTTPClient(force_instance=True)
         self._client.configure(None, defaults={'user_agent': _USER_AGENT})
         self._database = database
         self._influxdb_url = '{}?db={}'.format(url, database)
@@ -136,6 +135,9 @@ class InfluxDBCollector(object):
         self._max_batch_size = max_batch_size or self.MAX_BATCH_SIZE
         self._pending = 0
         self._tags = tags or {}
+
+        self._client = httpclient.AsyncHTTPClient(force_instance=True,
+                                                  io_loop=self._io_loop)
 
         # Add the periodic callback for submitting metrics
         LOGGER.info('Starting PeriodicCallback for writing InfluxDB metrics')

--- a/sprockets/mixins/metrics/statsd.py
+++ b/sprockets/mixins/metrics/statsd.py
@@ -2,6 +2,9 @@ import contextlib
 import socket
 import time
 
+SETTINGS_KEY = 'sprockets.mixins.metrics.statsd'
+"""``self.settings`` key that configures this mix-in."""
+
 
 class StatsdMixin(object):
     """
@@ -22,13 +25,9 @@ class StatsdMixin(object):
         this defaults to ``8125``.
 
     """
-
-    SETTINGS_KEY = 'sprockets.mixins.metrics.statsd'
-    """``self.settings`` key that configures this mix-in."""
-
     def initialize(self):
         super(StatsdMixin, self).initialize()
-        settings = self.settings.setdefault(self.SETTINGS_KEY, {})
+        settings = self.settings.setdefault(SETTINGS_KEY, {})
         if 'socket' not in settings:
             sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM, 0)
             settings['socket'] = sock
@@ -97,8 +96,7 @@ class StatsdMixin(object):
         try:
             yield
         finally:
-            fini = max(start, time.time())
-            self.record_timing(fini - start, *path)
+            self.record_timing(max(start, time.time()) - start, *path)
 
     def on_finish(self):
         """
@@ -119,12 +117,12 @@ class StatsdMixin(object):
 
     def _build_path(self, path):
         """Return a normalized path."""
-        return '{}.{}'.format(self.settings[self.SETTINGS_KEY]['namespace'],
+        return '{}.{}'.format(self.settings[SETTINGS_KEY]['namespace'],
                               '.'.join(str(p).replace('.', '-') for p in path))
 
     def _send(self, path, value, stat_type):
         """Send a metric to Statsd."""
-        settings = self.settings[self.SETTINGS_KEY]
+        settings = self.settings[SETTINGS_KEY]
         msg = '{0}:{1}|{2}'.format(path, value, stat_type)
         settings['socket'].sendto(msg.encode('ascii'),
                                   (settings['host'], int(settings['port'])))


### PR DESCRIPTION
**This change breaks existing usage of the API.**
- Change to having a persistent collector class that submits metrics to InfluxDB in batches on a periodic callback.
- Implement an install and shutdown method
