### PR TITLE
Fix adding tags in initialize

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -56,15 +56,15 @@ implements the same interface:
 
 Statsd Implementation
 ---------------------
-.. autoclass:: sprockets.mixins.metrics.StatsdMixin
+.. autoclass:: sprockets.mixins.metrics.statsd.StatsdMixin
    :members:
 
 InfluxDB Implementation
 -----------------------
-.. autoclass:: sprockets.mixins.metrics.InfluxDBMixin
+.. autoclass:: sprockets.mixins.metrics.influxdb.InfluxDBMixin
    :members:
 
-.. autoclass:: sprockets.mixins.metrics.influxdb.InfluxDBConnection
+.. autoclass:: sprockets.mixins.metrics.influxdb.InfluxDBCollector
    :members:
 
 Testing Helpers

--- a/docs/history.rst
+++ b/docs/history.rst
@@ -3,6 +3,12 @@
 Release History
 ===============
 
+`Next Release`_
+---------------
+- Make it possible to call methods (e.g.,
+  :meth:`~sprockets.mixins.metrics.influxdb.InfluxDBMixin.set_metric_tag`)
+  during the Tornado request handler initialization phase.
+
 `2.0.0`_ (11-Mar-2016)
 ----------------------
 - Rework InfluxDB buffering to use a periodic callback instead of flushing

--- a/docs/history.rst
+++ b/docs/history.rst
@@ -3,8 +3,8 @@
 Release History
 ===============
 
-`Next Release`_
----------------
+`2.0.1`_ (21-Mar-2016)
+----------------------
 - Make it possible to call methods (e.g.,
   :meth:`~sprockets.mixins.metrics.influxdb.InfluxDBMixin.set_metric_tag`)
   during the Tornado request handler initialization phase.
@@ -40,7 +40,8 @@ Release History
 - Add :class:`sprockets.mixins.metrics.InfluxDBMixin`
 - Add :class:`sprockets.mixins.metrics.influxdb.InfluxDBConnection`
 
-.. _Next Release: https://github.com/sprockets/sprockets.mixins.metrics/compare/2.0.0...master
+.. _Next Release: https://github.com/sprockets/sprockets.mixins.metrics/compare/2.0.1...master
+.. _2.0.1: https://github.com/sprockets/sprockets.mixins.metrics/compare/2.0.0...2.0.1
 .. _2.0.0: https://github.com/sprockets/sprockets.mixins.metrics/compare/1.1.1...2.0.0
 .. _1.1.1: https://github.com/sprockets/sprockets.mixins.metrics/compare/1.1.0...1.1.1
 .. _1.1.0: https://github.com/sprockets/sprockets.mixins.metrics/compare/1.0.1...1.1.0

--- a/examples/influxdb.py
+++ b/examples/influxdb.py
@@ -31,6 +31,10 @@ class SimpleHandler(influxdb.InfluxDBMixin, web.RequestHandler):
 
     """
 
+    def initialize(self):
+        super(SimpleHandler, self).initialize()
+        self.set_metric_tag('environment', 'testing')
+
     @gen.coroutine
     def prepare(self):
         maybe_future = super(SimpleHandler, self).prepare()

--- a/sprockets/mixins/metrics/__init__.py
+++ b/sprockets/mixins/metrics/__init__.py
@@ -1,3 +1,3 @@
-version_info = (2, 0, 0)
+version_info = (2, 0, 1)
 __version__ = '.'.join(str(v) for v in version_info)
 __all__ = ['__version__', 'version_info']

--- a/sprockets/mixins/metrics/influxdb.py
+++ b/sprockets/mixins/metrics/influxdb.py
@@ -20,13 +20,17 @@ class InfluxDBMixin(object):
     """Mix this class in to record measurements to a InfluxDB server."""
 
     def __init__(self, application, request, **kwargs):
-        super(InfluxDBMixin, self).__init__(application, request, **kwargs)
         self.__metrics = []
         self.__tags = {
             'handler': '{}.{}'.format(self.__module__,
                                       self.__class__.__name__),
             'method': request.method,
         }
+
+        # Call to super().__init__() needs to be *AFTER* we create our
+        # properties since it calls initialize() which may want to call
+        # methods like ``set_metric_tag``
+        super(InfluxDBMixin, self).__init__(application, request, **kwargs)
 
     def set_metric_tag(self, tag, value):
         """


### PR DESCRIPTION
`tornado.web.RequestHandler.__init__` calls `tornado.web.RequestHandler.initialize` to initialize the object. Sub-classes should be able to call our methods to tag metrics in their `initialize` implementations.  For this to work we need to set our internal attributes _BEFORE_ we call `super.__init__`.

This addresses tracebacks like the following:

```
tornado.application: ERROR: Uncaught exception
Traceback (most recent call last):
  File "/Users/daves/Source/platform/scheduler/env/lib/python3.5/site-packages/tornado/http1connection.py", line 238, in _read_message
    delegate.finish()
  File "/Users/daves/Source/platform/scheduler/env/lib/python3.5/site-packages/tornado/httpserver.py", line 290, in finish
    self.delegate.finish()
  File "/Users/daves/Source/platform/scheduler/env/lib/python3.5/site-packages/tornado/web.py", line 1984, in finish
    self.execute()
  File "/Users/daves/Source/platform/scheduler/env/lib/python3.5/site-packages/tornado/web.py", line 2004, in execute
    **self.handler_kwargs)
  File "/Users/daves/Source/platform/scheduler/env/lib/python3.5/site-packages/sprockets/mixins/correlation/mixins.py", line 40, in __init__
    super(HandlerMixin, self).__init__(*args, **kwargs)
  File "/Users/daves/Source/platform/scheduler/env/lib/python3.5/site-packages/sprockets/mixins/metrics/influxdb.py", line 23, in __init__
    super(InfluxDBMixin, self).__init__(application, request, **kwargs)
  File "/Users/daves/Source/platform/scheduler/env/lib/python3.5/site-packages/sprockets/mixins/sentry/__init__.py", line 70, in __init__
    super(SentryMixin, self).__init__(*args, **kwargs)
  File "/Users/daves/Source/platform/scheduler/env/lib/python3.5/site-packages/tornado/web.py", line 185, in __init__
    self.initialize(**kwargs)
  File "/Users/daves/Source/platform/scheduler/scheduler/handlers.py", line 115, in initialize
    self.set_metric_tag('environment', self.settings['environment'])
  File "/Users/daves/Source/platform/scheduler/env/lib/python3.5/site-packages/sprockets/mixins/metrics/influxdb.py", line 42, in set_metric_tag
    self.__tags[tag] = value
AttributeError: 'EventsHandler' object has no attribute '_InfluxDBMixin__tags'
```
