### PR TITLE
Use get_status to retrieve status code

### DIFF
--- a/docs/history.rst
+++ b/docs/history.rst
@@ -3,6 +3,10 @@
 Release History
 ===============
 
+`3.0.3`_ (24-Mar-2017)
+----------------------
+- Fix retrival of status code.
+
 `3.0.2`_ (12-Dec-2016)
 ----------------------
 - Fix influxdb test that fails intermittently.
@@ -63,7 +67,8 @@ Release History
 - Add :class:`sprockets.mixins.metrics.InfluxDBMixin`
 - Add :class:`sprockets.mixins.metrics.influxdb.InfluxDBConnection`
 
-.. _Next Release: https://github.com/sprockets/sprockets.mixins.metrics/compare/3.0.2...master
+.. _Next Release: https://github.com/sprockets/sprockets.mixins.metrics/compare/3.0.3...master
+.. _3.0.3: https://github.com/sprockets/sprockets.mixins.metrics/compare/3.0.2...3.0.3
 .. _3.0.2: https://github.com/sprockets/sprockets.mixins.metrics/compare/3.0.1...3.0.2
 .. _3.0.1: https://github.com/sprockets/sprockets.mixins.metrics/compare/3.0.0...3.0.1
 .. _3.0.0: https://github.com/sprockets/sprockets.mixins.metrics/compare/2.1.1...3.0.0

--- a/sprockets/mixins/metrics/__init__.py
+++ b/sprockets/mixins/metrics/__init__.py
@@ -1,3 +1,3 @@
-version_info = (3, 0, 2)
+version_info = (3, 0, 3)
 __version__ = '.'.join(str(v) for v in version_info)
 __all__ = ['__version__', 'version_info']

--- a/sprockets/mixins/metrics/influxdb.py
+++ b/sprockets/mixins/metrics/influxdb.py
@@ -93,7 +93,7 @@ class InfluxDBMixin(object):
 
     def on_finish(self):
         super(InfluxDBMixin, self).on_finish()
-        self.set_metric_tag('status_code', self._status_code)
+        self.set_metric_tag('status_code', self.get_status())
         self.record_timing(self.request.request_time(), 'duration')
         self.application.influxdb.submit(
             self.settings[SETTINGS_KEY]['measurement'],

--- a/sprockets/mixins/metrics/statsd.py
+++ b/sprockets/mixins/metrics/statsd.py
@@ -15,7 +15,6 @@ class StatsdMixin(object):
 
     def initialize(self):
         super(StatsdMixin, self).initialize()
-        self.__status_code = None
 
     def set_metric_tag(self, tag, value):
         """Ignored for statsd since it does not support tagging.
@@ -90,21 +89,7 @@ class StatsdMixin(object):
         super(StatsdMixin, self).on_finish()
         self.record_timing(self.request.request_time(),
                            self.__class__.__name__, self.request.method,
-                           self.__status_code)
-
-    def set_status(self, status_code, reason=None):
-        """Extend tornado `set_status` method to track status code
-        to avoid referencing the _status internal variable
-
-        :param int status_code: Response status code. If ``reason``
-            is ``None``, it must be present in `httplib.responses
-            <http.client.responses>`.
-        :param string reason: Human-readable reason phrase describing
-            the status code. If ``None``, it will be filled in from
-            `httplib.responses <http.client.responses>`.
-        """
-        self.__status_code = status_code
-        super(StatsdMixin, self).set_status(status_code, reason=reason)
+                           self.get_status())
 
 
 class StatsDCollector(object):


### PR DESCRIPTION
By default, Tornado sets the status coded to 200. Thus, a 200 is returned in the response if set_status is not called. However, `StatsdMixin` relies upon a call to `set_status` to set the status of the metric. When `set_status` is not called, the metric is recorded with a status code of `None`.

Using Tornado's built-in `get_status` method alleviates the need to keep a private copy of the status code and correctly retrieves the status code when not explicitly set.